### PR TITLE
Include hardhat local network to not throw

### DIFF
--- a/src/chainsExtraData.ts
+++ b/src/chainsExtraData.ts
@@ -292,5 +292,9 @@ export const chainsExtraData: IChainExtraData[] = [
   {
     blockExplorerUrls: ['https://blockscout.com/poa/core'],
     chainId: 99
+  },
+  {
+    blockExplorerUrls: [],
+    chainId: 31337
   }
 ]


### PR DESCRIPTION
I'm following this tutorial: https://www.youtube.com/watch?v=N5nB__oueYc (to connect to pool together contracts deployed on a local hardhat node)

But it throws here: 

```
export const formatBlockExplorerAddressUrl = (address, networkId) => {
  try {
    const blockExplorerUrl = getChain(networkId).blockExplorerUrls[0]
    return `${blockExplorerUrl}/address/${address}`
  } catch (e) {
    throw new Error('Chain ID not supported')
  }
}
```

Adding entry for the local hardhat chain ID silences this.